### PR TITLE
Load batches: randomization and bug fixes

### DIFF
--- a/src/datasets/batch_data.py
+++ b/src/datasets/batch_data.py
@@ -284,7 +284,8 @@ if __name__=="__main__":
         None, 
         h5_path=args.h5_path, 
         overwrite_previous=False,
-        in_memory=False)
+        in_memory=False,
+        shuffle=True)
     import sys
 
     # batch training, testing sets

--- a/src/datasets/data_utils.py
+++ b/src/datasets/data_utils.py
@@ -6,7 +6,7 @@ import numpy as np
 import logging
 logging.basicConfig()
 logger=logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.WARNING)
 
 class DataException(Exception):
     pass
@@ -16,7 +16,8 @@ class TextTooShortException(DataException):
 
 def normalize(txt, vocab=None, replace_char=' ',
                 min_length=100, max_length=1014, pad_out=True, 
-                to_lower=True, reverse = True, encoding="latin1"):
+                to_lower=True, reverse = True, 
+                truncate_left=False, encoding="latin1"):
     ''' Takes a single string object and truncates it to max_length,
     raises an exception if its length does not exceed min_length, and
     performs case normalization if to_lower is True. Optionally
@@ -54,7 +55,10 @@ def normalize(txt, vocab=None, replace_char=' ',
     if len(txt) < min_length:
         raise TextTooShortException("Too short: {}".format(len(txt)))
     # truncate if too long
-    txt = txt[0:max_length]
+    if truncate_left:
+        txt = txt[-max_length:]
+    else:    
+        txt = txt[0:max_length]
     # change case
     if to_lower==True:
         txt = txt.lower()

--- a/src/datasets/neon_iterator.py
+++ b/src/datasets/neon_iterator.py
@@ -26,7 +26,7 @@ import gzip
 import logging
 logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.WARNING)
 
 from neon import NervanaObject
 
@@ -42,7 +42,7 @@ from data_utils import from_one_hot
 
 class DiskDataIterator(NervanaObject):
 
-    def __init__(self, batch_gen_fun, ndata, doclength=1014, nvocab=67, nlabels=2):
+    def __init__(self, batch_gen_fun, ndata, doclength, nvocab, nlabels=2):
         """
         Implements loading of given data into backend tensor objects. If the
         backend is specific to an accelarator device, the data is copied over
@@ -53,7 +53,7 @@ class DiskDataIterator(NervanaObject):
                 batches (tuples of numpy arrays)
             ndata (int): The number of records in the given data
             nlabels (int, optional): The number of possible types of labels. 2 for binary good/bad
-            nvocab  (int, optional): Tne number of letter tokens
+            nvocab  (int, optional): The number of letter tokens
                 (not necessary if not providing labels)
         """
         # Treat singletons like list so that iteration follows same syntax
@@ -73,12 +73,12 @@ class DiskDataIterator(NervanaObject):
         self.nsteps = doclength  # removing 1 for the label at the front
 
         # on device tensor for review chars and one hot
-        self.xlabels_flat = self.be.iobuf((1, self.nsteps), dtype=np.int32)
+        self.xlabels_flat = self.be.iobuf((1, self.nsteps), dtype=np.int16)
         self.xlabels = self.xlabels_flat.reshape((self.nsteps, self.be.bsz))
         self.Xbuf_flat = self.be.iobuf((self.nvocab, self.nsteps))
         self.Xbuf = self.Xbuf_flat.reshape((self.nvocab * self.nsteps, self.be.bsz))
 
-        self.ylabels = self.be.iobuf(1, dtype=np.int32)
+        self.ylabels = self.be.iobuf(1, dtype=np.int16)
         self.ybuf = self.be.iobuf(self.nlabels)
 
         # This makes upstream layers interpret each example as a 1d image
@@ -134,6 +134,7 @@ class DiskDataIterator(NervanaObject):
 
             #self.Xbuf_flat[:] = self.be.onehot(self.xlabels_flat, axis=0)
             self.Xbuf[:] = X.T.copy()
+            logger.debug(self.Xbuf.shape)
             self.ybuf[:] = self.be.onehot(self.ylabels, axis=0)
             yield (self.Xbuf, self.ybuf)
 


### PR DESCRIPTION
Implements randomization in H5Iterator and split_data. H5Iterator is now a true iterator and will produce a new sequence of records every time it is iterated over (if shuffle is set to True). split_data no longer accepts in_memory as a parameter; all splitting is done on disk through HDF5. Some optional arguments to split_data and `DiskDataIterator.__init__` have been made required (easy to forget they've been set, leading to hard-to-debug consequences).