### PR TITLE
Lock in to neon version 1.0.0

### DIFF
--- a/frameworks/docker/neon-cuda/Dockerfile
+++ b/frameworks/docker/neon-cuda/Dockerfile
@@ -102,7 +102,7 @@ ENV LIBRARY_PATH /usr/local/lib:/usr/local/cuda/lib:$LD_LIBRARY_PATH
 RUN echo "/usr/local/cuda/lib64" > /etc/ld.so.conf.d/cuda.conf && \
     ldconfig
 
-# download/configure/install neon
+# download/configure/install neon 1.0.0
 RUN pip install virtualenv
 RUN cd /opt/ && \
     wget -nv https://github.com/NervanaSystems/neon/archive/v1.0.0.tar.gz

--- a/frameworks/docker/neon-cuda/Dockerfile
+++ b/frameworks/docker/neon-cuda/Dockerfile
@@ -103,7 +103,11 @@ RUN echo "/usr/local/cuda/lib64" > /etc/ld.so.conf.d/cuda.conf && \
     ldconfig
 
 # download/configure/install neon
-RUN cd /opt/ && git clone https://github.com/NervanaSystems/neon.git
+RUN pip install virtualenv
+RUN cd /opt/ && \
+    wget -nv https://github.com/NervanaSystems/neon/archive/v1.0.0.tar.gz
+RUN cd /opt && tar -xzvf v1.0.0.tar.gz && \
+    mv neon-1.0.0 neon
 RUN cd /opt/neon && \
     make sysinstall
 


### PR DESCRIPTION
neon has released 1.1.0 with some significant changes to interface and some apparently broken functionality. Given our time constraints, we should probably lock into their 1.0.0 release, warts and all.