### PR TITLE
Fix six version conflict for Neon Docker images

### DIFF
--- a/frameworks/docker/neon-cuda/Dockerfile
+++ b/frameworks/docker/neon-cuda/Dockerfile
@@ -134,6 +134,14 @@ RUN cd /tmp && \
     python setup.py install && \
     rm -rf *
 
+
+# six version conflict (1.5.2 vs 1.9+)
+RUN echo "\ndeb http://archive.ubuntu.com/ubuntu/ vivid main" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install python-six
+
+#RUN dpkg -r --force-depends python-six && apt-mark hold python-six
+
 # default to shell in root dir
 WORKDIR /root
 CMD ["/bin/bash"]

--- a/frameworks/docker/neon-cuda/Dockerfile
+++ b/frameworks/docker/neon-cuda/Dockerfile
@@ -140,8 +140,6 @@ RUN echo "\ndeb http://archive.ubuntu.com/ubuntu/ vivid main" >> /etc/apt/source
     apt-get update && \
     apt-get install python-six
 
-#RUN dpkg -r --force-depends python-six && apt-mark hold python-six
-
 # default to shell in root dir
 WORKDIR /root
 CMD ["/bin/bash"]

--- a/frameworks/docker/neon-cuda7.5/Dockerfile
+++ b/frameworks/docker/neon-cuda7.5/Dockerfile
@@ -132,6 +132,11 @@ RUN cd /tmp && \
     python setup.py install && \
     rm -rf *
 
+# six version conflict (1.5.2 vs 1.9+)
+RUN echo "\ndeb http://archive.ubuntu.com/ubuntu/ vivid main" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install python-six
+
 # default to shell in root dir
 WORKDIR /root
 CMD ["/bin/bash"]


### PR DESCRIPTION
Adds vivid repositories to trusty images for installing python-six, which neon (I think?) had installed at a higher version (1.9+), but further down the list of default import paths from the system distribution (1.5.2). Without replacing the system install, I couldn't get neon to import six properly with any path environment variable trickery, but this fix is probably too fragile. Will open an issue and fiddle around when there is time, but if anyone needs neon this will work.